### PR TITLE
[PR] Fixing layout and item card on web devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3327,22 +3327,74 @@ and change accordingly in case the contents
 exceed the width of its boundaries.
 
 In order to have our app adapt to bigger screens,
-we can leverage two packages
-that will make it easy for us
-to adapt the `Text` and `Textfield` objects
-on bigger screens:
-- [`auto_size_text`](https://pub.dev/packages/auto_size_text) for `Text` widgets.
-- [`auto_size_text_field`](https://pub.dev/packages/auto_size_text_field)
-for `Textfield` widgets.
+we can create a simple widget
+that will render whatever we want
+according to **screen width breakpoints**.
 
-If you are curious to see the changes needed 
-for the tests and the widgets,
-please check the following commits:
+Let's create a file called
+`breakpoints.dart` inside `lib`
+and use the following code.
 
--  [`7ef7198`](https://github.com/dwyl/flutter-bloc-tutorial/pull/5/commits/7ef719858bde6b69750eb8b414f8a241b7bef8b2)
-for changes on the widgets.
-- [45b96b5](https://github.com/dwyl/flutter-bloc-tutorial/pull/5/commits/45b96b56686c7c71206a16d9adde8420d24a7b48)
-for tests.
+```dart
+import 'package:flutter/material.dart';
+
+const kMobileBreakpoint = 425.0;
+const kTabletBreakpoint = 768.0;
+const kDesktopBreakpoint = 1024.0;
+const kDesktopLargeBreakpoint = 1440.0;
+
+class ResponsiveLayout extends StatelessWidget {
+  final Widget mobileBody;
+  final Widget? tabletBody;
+  final Widget? desktopBody;
+
+  const ResponsiveLayout({super.key, required this.mobileBody, this.tabletBody, this.desktopBody});
+
+  @override
+  Widget build(BuildContext context) {
+
+    double deviceWidth = MediaQuery.of(context).size.width;
+
+    return LayoutBuilder(builder: (_, __) {
+      if (deviceWidth < kMobileBreakpoint) {
+        return mobileBody;
+      } else if (deviceWidth < kTabletBreakpoint) {
+        return tabletBody ?? mobileBody;
+      } else {
+        return desktopBody ?? tabletBody ?? mobileBody;
+      }
+    });
+  }
+}
+```
+
+We are using `MediaQuery` 
+to conditionally render content
+with [`LayoutBuilder`](https://docs.flutter.dev/ui/layout/adaptive-responsive).
+
+And now we just need to use this widget
+to render widget according to different 
+screen sizes.
+We can do it like so,
+for example:
+
+```dart
+const ResponsiveLayout(
+mobileBody: Text(
+  'Save',
+  style: TextStyle(fontSize: 24),
+),
+tabletBody: Text(
+  'Save',
+  style: TextStyle(fontSize: 40),
+)),
+```
+
+
+If you are curious to see the changes needed,
+please check the following commit
+[`1b3dfc3`](https://github.com/dwyl/flutter-bloc-tutorial/pull/7/commits/1b3dfc30abb9ee6d8f3b27fc15447f9bc9210d6b).
+
 
 # I need help! ❓
 If you have some feedback or have any question, 

--- a/lib/breakpoints.dart
+++ b/lib/breakpoints.dart
@@ -14,7 +14,6 @@ class ResponsiveLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     double deviceWidth = MediaQuery.of(context).size.width;
 
     return LayoutBuilder(builder: (_, __) {

--- a/lib/breakpoints.dart
+++ b/lib/breakpoints.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+const kMobileBreakpoint = 425.0;
+const kTabletBreakpoint = 768.0;
+const kDesktopBreakpoint = 1024.0;
+const kDesktopLargeBreakpoint = 1440.0;
+
+class ResponsiveLayout extends StatelessWidget {
+  final Widget mobileBody;
+  final Widget? tabletBody;
+  final Widget? desktopBody;
+
+  const ResponsiveLayout({super.key, required this.mobileBody, this.tabletBody, this.desktopBody});
+
+  @override
+  Widget build(BuildContext context) {
+
+    double deviceWidth = MediaQuery.of(context).size.width;
+
+    return LayoutBuilder(builder: (_, __) {
+      if (deviceWidth < kMobileBreakpoint) {
+        return mobileBody;
+      } else if (deviceWidth < kTabletBreakpoint) {
+        return tabletBody ?? mobileBody;
+      } else {
+        return desktopBody ?? tabletBody ?? mobileBody;
+      }
+    });
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -360,10 +360,19 @@ class _ItemCardState extends State<ItemCard> {
       constraints: const BoxConstraints(minHeight: 70),
       child: ListTile(
         onTap: () {
-          // Create a ToggleTodo event to toggle the `complete` field
-          // ONLY if the timer is stopped
+          // If the stopwatch is not running, we mark toggle it
           if (!_stopwatch.isRunning) {
             context.read<TodoBloc>().add(ToggleTodoEvent(widget.item));
+          } 
+          
+          // If the stopwatch is running, we toggle the item but also stop the timer
+          else {
+            context.read<TodoBloc>().add(ToggleTodoEvent(widget.item));
+            widget.item.stopTimer();
+            _stopwatch.stop();
+
+            // Re-render
+            setState(() {});
           }
         },
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
-import 'package:auto_size_text/auto_size_text.dart';
-import 'package:auto_size_text_field/auto_size_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:todo/bloc/todo_bloc.dart';
+import 'package:todo/breakpoints.dart';
 import 'package:todo/stopwatch.dart';
 import 'package:todo/item.dart';
 import 'package:todo/utils.dart';
@@ -54,19 +53,35 @@ class HomePage extends StatelessWidget {
               return SafeArea(
                 child: Column(
                   children: [
-                    AutoSizeTextField(
-                        key: textfieldKey,
-                        controller: TextEditingController(),
-                        keyboardType: TextInputType.none,
-                        onTap: () {
-                          Navigator.of(context).push(navigateToNewTodoItemPage());
-                        },
-                        minFontSize: 24,
-                        stepGranularity: 4,
-                        maxLines: 2,
-                        decoration: const InputDecoration(
-                            border: OutlineInputBorder(borderRadius: BorderRadius.zero), hintText: 'Capture more things on your mind...'),
-                        textAlignVertical: TextAlignVertical.top),
+                    ResponsiveLayout(
+                      // On mobile
+                      mobileBody: TextField(
+                          key: textfieldKey,
+                          controller: TextEditingController(),
+                          keyboardType: TextInputType.none,
+                          onTap: () {
+                            Navigator.of(context).push(navigateToNewTodoItemPage());
+                          },
+                          maxLines: 2,
+                          style: const TextStyle(fontSize: 20),
+                          decoration: const InputDecoration(
+                              border: OutlineInputBorder(borderRadius: BorderRadius.zero), hintText: 'Capture more things on your mind...'),
+                          textAlignVertical: TextAlignVertical.top),
+
+                      // On tablet
+                      tabletBody: TextField(
+                          key: textfieldKey,
+                          controller: TextEditingController(),
+                          keyboardType: TextInputType.none,
+                          onTap: () {
+                            Navigator.of(context).push(navigateToNewTodoItemPage());
+                          },
+                          maxLines: 2,
+                          style: const TextStyle(fontSize: 30),
+                          decoration: const InputDecoration(
+                              border: OutlineInputBorder(borderRadius: BorderRadius.zero), hintText: 'Capture more things on your mind...'),
+                          textAlignVertical: TextAlignVertical.top),
+                    ),
 
                     // List of items
                     Expanded(
@@ -141,16 +156,30 @@ class _NewTodoPageState extends State<NewTodoPage> {
                 children: [
                   // Textfield that is expanded and borderless
                   Expanded(
-                    child: AutoSizeTextField(
-                      key: textfieldOnNewPageKey,
-                      controller: txtFieldController,
-                      expands: true,
-                      maxLines: null,
-                      autofocus: true,
-                      maxFontSize: 50,
-                      minFontSize: 24,
-                      decoration: const InputDecoration(border: OutlineInputBorder(borderRadius: BorderRadius.zero), hintText: 'start typing'),
-                      textAlignVertical: TextAlignVertical.top,
+                    child: ResponsiveLayout(
+                      // On mobile
+                      mobileBody: TextField(
+                        key: textfieldOnNewPageKey,
+                        controller: txtFieldController,
+                        expands: true,
+                        maxLines: null,
+                        autofocus: true,
+                        style: const TextStyle(fontSize: 20),
+                        decoration: const InputDecoration(border: OutlineInputBorder(borderRadius: BorderRadius.zero), hintText: 'start typing'),
+                        textAlignVertical: TextAlignVertical.top,
+                      ),
+
+                      // On tablet
+                      tabletBody: TextField(
+                        key: textfieldOnNewPageKey,
+                        controller: txtFieldController,
+                        expands: true,
+                        maxLines: null,
+                        autofocus: true,
+                        style: const TextStyle(fontSize: 30),
+                        decoration: const InputDecoration(border: OutlineInputBorder(borderRadius: BorderRadius.zero), hintText: 'start typing'),
+                        textAlignVertical: TextAlignVertical.top,
+                      ),
                     ),
                   ),
 
@@ -178,11 +207,15 @@ class _NewTodoPageState extends State<NewTodoPage> {
                           Navigator.pop(context);
                         }
                       },
-                      child: const AutoSizeText(
-                        'Save',
-                        maxLines: 1,
-                        presetFontSizes: [25, 14],
-                      ),
+                      child: const ResponsiveLayout(
+                          mobileBody: Text(
+                            'Save',
+                            style: TextStyle(fontSize: 24),
+                          ),
+                          tabletBody: Text(
+                            'Save',
+                            style: TextStyle(fontSize: 40),
+                          )),
                     ),
                   ),
                 ],
@@ -320,7 +353,6 @@ class _ItemCardState extends State<ItemCard> {
   Widget build(BuildContext context) {
     double deviceWidth = MediaQuery.of(context).size.width;
 
-    double descriptionFontSize = deviceWidth * .07;
     double checkboxSize = deviceWidth > 425 ? 30 : 20;
 
     return Container(
@@ -360,40 +392,70 @@ class _ItemCardState extends State<ItemCard> {
             Expanded(
               child: Container(
                 margin: const EdgeInsets.only(right: 16.0),
-                child: AutoSizeText(widget.item.description,
-                    maxLines: 1,
-                    minFontSize: 10,
-                    maxFontSize: 25,
-                    style: TextStyle(
-                        fontSize: descriptionFontSize,
-                        decoration: widget.item.completed ? TextDecoration.lineThrough : TextDecoration.none,
-                        fontStyle: widget.item.completed ? FontStyle.italic : FontStyle.normal,
-                        color: widget.item.completed ? const Color.fromARGB(255, 126, 121, 121) : Colors.black)),
+                child: ResponsiveLayout(
+                  // On mobile
+                  mobileBody: Text(widget.item.description,
+                      style: TextStyle(
+                          fontSize: 20,
+                          decoration: widget.item.completed ? TextDecoration.lineThrough : TextDecoration.none,
+                          fontStyle: widget.item.completed ? FontStyle.italic : FontStyle.normal,
+                          color: widget.item.completed ? const Color.fromARGB(255, 126, 121, 121) : Colors.black)),
+
+                  // On tablet
+                  tabletBody: Text(widget.item.description,
+                      style: TextStyle(
+                          fontSize: 25,
+                          decoration: widget.item.completed ? TextDecoration.lineThrough : TextDecoration.none,
+                          fontStyle: widget.item.completed ? FontStyle.italic : FontStyle.normal,
+                          color: widget.item.completed ? const Color.fromARGB(255, 126, 121, 121) : Colors.black)),
+                ),
               ),
             ),
 
             // Stopwatch and timer button
             Column(
               children: [
-                AutoSizeText(formatTime(_stopwatch.elapsedMilliseconds),
-                    maxLines: 1, minFontSize: 10, maxFontSize: 40, style: const TextStyle(color: Colors.black54)),
+                ResponsiveLayout(
+                  // On mobile
+                  mobileBody: Text(formatTime(_stopwatch.elapsedMilliseconds), maxLines: 1, style: const TextStyle(color: Colors.black54)),
+
+                  // On tablet
+                  tabletBody:
+                      Text(formatTime(_stopwatch.elapsedMilliseconds), maxLines: 1, style: const TextStyle(color: Colors.black54, fontSize: 18)),
+                ),
 
                 // If the item is completed, we hide the button
                 if (!widget.item.completed)
-                  ElevatedButton(
-                    key: itemCardTimerButtonKey,
-                    style: ElevatedButton.styleFrom(
-                        backgroundColor: _renderButtonBackground(),
-                        elevation: 0,
-                        shape: const RoundedRectangleBorder(borderRadius: BorderRadius.zero)),
-                    onPressed: _handleButtonClick,
-                    child: AutoSizeText(
-                      _renderButtonText(),
-                      maxLines: 1,
-                      minFontSize: 10,
-                      maxFontSize: 30,
-                    ),
-                  ),
+                  ResponsiveLayout(
+
+                      // On mobile
+                      mobileBody: ElevatedButton(
+                        key: itemCardTimerButtonKey,
+                        style: ElevatedButton.styleFrom(
+                            backgroundColor: _renderButtonBackground(),
+                            elevation: 0,
+                            shape: const RoundedRectangleBorder(borderRadius: BorderRadius.zero)),
+                        onPressed: _handleButtonClick,
+                        child: Text(
+                          _renderButtonText(),
+                          maxLines: 1,
+                        ),
+                      ),
+
+                      // On tablet
+                      tabletBody: ElevatedButton(
+                        key: itemCardTimerButtonKey,
+                        style: ElevatedButton.styleFrom(
+                            backgroundColor: _renderButtonBackground(),
+                            elevation: 0,
+                            shape: const RoundedRectangleBorder(borderRadius: BorderRadius.zero)),
+                        onPressed: _handleButtonClick,
+                        child: Text(
+                          _renderButtonText(),
+                          maxLines: 1,
+                          style: const TextStyle(fontSize: 20),
+                        ),
+                      )),
               ],
             )
           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,6 @@ dependencies:
   bloc_test: ^9.1.1
   equatable: ^2.0.0
   uuid: ^3.0.6
-  auto_size_text: ^3.0.0
-  auto_size_text_field: ^2.2.1
 
 dev_dependencies:
   flutter_test:

--- a/test/widget/widget_test.dart
+++ b/test/widget/widget_test.dart
@@ -1,4 +1,3 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:todo/main.dart';
@@ -118,7 +117,7 @@ void main() {
     ElevatedButton buttonWidget = tester.firstWidget<ElevatedButton>(find.byKey(itemCardTimerButtonKey));
 
     // Button should be stopped
-    AutoSizeText buttonText = buttonWidget.child as AutoSizeText;
+    Text buttonText = buttonWidget.child as Text;
     expect(buttonText.data, "Start");
 
     // Tap on timer button.
@@ -128,7 +127,7 @@ void main() {
 
     // Updating widget and button should be ongoing
     buttonWidget = tester.firstWidget<ElevatedButton>(find.byKey(itemCardTimerButtonKey));
-    buttonText = buttonWidget.child as AutoSizeText;
+    buttonText = buttonWidget.child as Text;
     expect(buttonText.data, "Stop");
 
     // Tap on timer button AGAIN
@@ -138,7 +137,7 @@ void main() {
 
     // Updating widget and button should be stopped
     buttonWidget = tester.firstWidget<ElevatedButton>(find.byKey(itemCardTimerButtonKey));
-    buttonText = buttonWidget.child as AutoSizeText;
+    buttonText = buttonWidget.child as Text;
     expect(buttonText.data, "Resume");
   });
 

--- a/test/widget/widget_test.dart
+++ b/test/widget/widget_test.dart
@@ -52,6 +52,105 @@ void main() {
     expect(find.byKey(itemCardWidgetKey), findsOneWidget);
   });
 
+  testWidgets('Adding a new todo item shows a card (on mobile screen)', (WidgetTester tester) async {
+    // Ensure binding is initialized to setup camera size
+
+    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.window.physicalSizeTestValue = const Size(400, 600);
+    binding.window.devicePixelRatioTestValue = 1.0;
+
+    await tester.pumpWidget(const MainApp());
+    await tester.pumpAndSettle();
+
+    // Find the text input and string stating 0 todos created
+    expect(find.byKey(textfieldKey), findsOneWidget);
+    expect(find.byKey(itemCardWidgetKey), findsNothing);
+
+    // Tap textfield to open new page to create todo item
+    await tester.tap(find.byKey(textfieldKey));
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    // Type text into todo input
+    await tester.enterText(find.byKey(textfieldOnNewPageKey), 'new todo');
+    expect(
+        find.descendant(
+          of: find.byKey(textfieldOnNewPageKey),
+          matching: find.text('new todo'),
+        ),
+        findsOneWidget);
+
+    // Tap "Save" button to add new todo item
+    await tester.tap(find.byKey(saveButtonKey));
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    // Input is cleared
+    expect(
+      find.descendant(
+        of: find.byKey(textfieldOnNewPageKey),
+        matching: find.text('new todo'),
+      ),
+      findsNothing,
+    );
+
+    // Pump the widget so it renders the new item
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    // Expect to find at least one widget, pertaining to the one that was added
+    expect(find.byKey(itemCardWidgetKey), findsOneWidget);
+
+    // Resetting camera size to normal
+    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+  });
+
+  testWidgets('Adding a new todo item shows a card (on tablet screen)', (WidgetTester tester) async {
+    // Ensure binding is initialized to setup camera size
+    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.window.physicalSizeTestValue = const Size(600, 600);
+    binding.window.devicePixelRatioTestValue = 1.0;
+
+    await tester.pumpWidget(const MainApp());
+    await tester.pumpAndSettle();
+
+    // Find the text input and string stating 0 todos created
+    expect(find.byKey(textfieldKey), findsOneWidget);
+    expect(find.byKey(itemCardWidgetKey), findsNothing);
+
+    // Tap textfield to open new page to create todo item
+    await tester.tap(find.byKey(textfieldKey));
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    // Type text into todo input
+    await tester.enterText(find.byKey(textfieldOnNewPageKey), 'new todo');
+    expect(
+        find.descendant(
+          of: find.byKey(textfieldOnNewPageKey),
+          matching: find.text('new todo'),
+        ),
+        findsOneWidget);
+
+    // Tap "Save" button to add new todo item
+    await tester.tap(find.byKey(saveButtonKey));
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    // Input is cleared
+    expect(
+      find.descendant(
+        of: find.byKey(textfieldOnNewPageKey),
+        matching: find.text('new todo'),
+      ),
+      findsNothing,
+    );
+
+    // Pump the widget so it renders the new item
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    // Expect to find at least one widget, pertaining to the one that was added
+    expect(find.byKey(itemCardWidgetKey), findsOneWidget);
+
+    // Resetting camera size to normal
+    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+  });
+
   testWidgets('Adding a new todo item and checking it as done', (WidgetTester tester) async {
     await tester.pumpWidget(const MainApp());
     await tester.pumpAndSettle();
@@ -90,7 +189,7 @@ void main() {
     expect(checkboxWidget.icon, Icons.check_box);
   });
 
-  testWidgets('Adding a new todo item and clicking timer button', (WidgetTester tester) async {
+  testWidgets('Adding a new todo item and clicking timer button and marking it as done while it\'s running', (WidgetTester tester) async {
     await tester.pumpWidget(const MainApp());
     await tester.pumpAndSettle();
 
@@ -139,6 +238,26 @@ void main() {
     buttonWidget = tester.firstWidget<ElevatedButton>(find.byKey(itemCardTimerButtonKey));
     buttonText = buttonWidget.child as Text;
     expect(buttonText.data, "Resume");
+
+    // Tap on timer button AGAIN x2
+    await tester.tap(find.byKey(itemCardTimerButtonKey));
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    // Updating widget and button should be ongoing
+    buttonWidget = tester.firstWidget<ElevatedButton>(find.byKey(itemCardTimerButtonKey));
+    buttonText = buttonWidget.child as Text;
+    expect(buttonText.data, "Stop");
+
+    // Tap on item card while its ongoing
+    await tester.tap(find.byKey(itemCardWidgetKey));
+    await tester.pumpAndSettle();
+
+    // Item card should be marked as done
+    Finder checkboxFinder = find.descendant(of: find.byKey(itemCardWidgetKey), matching: find.byType(Icon));
+    Icon checkboxWidget = tester.firstWidget<Icon>(checkboxFinder);
+    checkboxWidget = tester.firstWidget<Icon>(checkboxFinder);
+    expect(checkboxWidget.icon, Icons.check_box);
   });
 
   testWidgets('Navigate to new page and go back', (WidgetTester tester) async {


### PR DESCRIPTION
closes #6 

This removes the packages that were previously being used and uses a simple `LayoutBuilder` custom widget that conditionally renders according to screen width breakpoints.

Additionally, if the item card's timer is running and the person wants to complete the todo, that's now possible (without having to stop the timer).